### PR TITLE
Tweak - Change View PRO version link to pricing link

### DIFF
--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -437,7 +437,7 @@ function himalayas_customize_register( $wp_customize ) {
 		new HIMALAYAS_Upsell_Section( $wp_customize, 'himalayas_upsell_section',
 			array(
 				'title'      => esc_html__( 'View PRO version', 'himalayas' ),
-				'url'        => 'https://themegrill.com/themes/himalayas/?utm_source=himalayas-customizer&utm_medium=view-pro-link&utm_campaign=view-pro#free-vs-pro',
+				'url'        => 'https://themegrill.com/himalayas-pricing/?utm_source=himalayas-customizer&utm_medium=view-pricing-link&utm_campaign=upgrade',
 				'capability' => 'edit_theme_options',
 				'priority'   => 1,
 			)


### PR DESCRIPTION
# Description
- I've changed the link of View PRO version in the Customizer option.
## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Changelog
A changelog is not required.
# Did you test this issue fix on all browsers?
- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer
# Checklist:
- [x] My code follows the WPCS
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have made perform test that proves my fix is effective or that my feature works